### PR TITLE
Conditionally polyfill globalThis.crypto

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,22 +31,10 @@ import {
   splitCookiesString,
 } from "set-cookie-parser";
 import { serialize } from "cookie";
-import crypto from "node:crypto";
 import { getConfig } from "./config";
 
 const { edge, authOptions } = getConfig();
 
-// Prior to Node 19.0.0, we need the following polyfills
-// This gives us at the very least support for Node ^17.4.0
-// See: https://github.com/nextauthjs/next-auth/issues/6417#issuecomment-1384660656
-if (!edge) {
-  if (!globalThis.crypto) globalThis.crypto = crypto;
-  if (typeof globalThis.crypto.subtle === "undefined")
-    // @ts-expect-error
-    globalThis.crypto.subtle = crypto.webcrypto.subtle;
-  if (typeof globalThis.crypto.randomUUID === "undefined")
-    globalThis.crypto.randomUUID = crypto.randomUUID;
-}
 export interface AstroAuthConfig extends AuthConfig {
   /**
    * Defines the base path for the auth routes.
@@ -130,7 +118,6 @@ function AstroAuthHandler(prefix: string) {
  */
 export function AstroAuth() {
   const { prefix = "/api/auth", ...authConfig } = authOptions;
-  // @ts-expect-error import.meta.env is used by Astro
   const { AUTH_SECRET, AUTH_TRUST_HOST, VERCEL, NODE_ENV } = import.meta.env;
 
   authConfig.secret ??= AUTH_SECRET;
@@ -157,7 +144,6 @@ export function AstroAuth() {
  * @returns The current session, or `null` if there is no session.
  */
 export async function getSession(req: Request): Promise<Session | null> {
-  // @ts-expect-error import.meta.env is used by Astro
   authOptions.secret ??= import.meta.env.AUTH_SECRET;
   authOptions.trustHost ??= true;
 

--- a/integration.ts
+++ b/integration.ts
@@ -1,11 +1,13 @@
-import { AstroIntegration } from "astro";
-import { AstroAuthIntegrationConfig, setConfig } from "./config";
+import type { AstroIntegration } from "astro";
+import { type AstroAuthIntegrationConfig, setConfig } from "./config";
 import { dirname } from "path";
 
 export default (config: AstroAuthIntegrationConfig): AstroIntegration => ({
   name: "astro-auth",
   hooks: {
-    "astro:config:setup": ({ injectRoute }) => {
+    "astro:config:setup": ({ config: astroConfig, injectRoute, injectScript }) => {
+      if (astroConfig.output === 'static') throw new Error('auth-astro requires server-side rendering. Please set output to "server" & install an adapter. See https://docs.astro.build/en/guides/deploy/#adding-an-adapter-for-ssr');
+
       config.edge ??= false;
       config.authOptions.prefix ??= "/api/auth";
       setConfig(config);
@@ -16,6 +18,14 @@ export default (config: AstroAuthIntegrationConfig): AstroIntegration => ({
           pattern: config.authOptions.prefix + "/[...auth]",
           entryPoint: currentDir + "/api/[...auth].ts",
         });
+      }
+
+      if (globalThis.process && process.versions.node < "19.0.0") {
+        injectScript('page-ssr', `import crypto from "node:crypto";
+if (!globalThis.crypto) globalThis.crypto = crypto;
+if (typeof globalThis.crypto.subtle === "undefined") globalThis.crypto.subtle = crypto.webcrypto.subtle;
+if (typeof globalThis.crypto.randomUUID === "undefined") globalThis.crypto.randomUUID = crypto.randomUUID;
+`)
       }
     },
   },


### PR DESCRIPTION
Checks for node runtime < v19. This allows edge runtimes to bundle & run correctly