### PR TITLE
Filter for non-node adapters

### DIFF
--- a/src/integration.ts
+++ b/src/integration.ts
@@ -33,7 +33,9 @@ export default (config: AstroAuthConfig): AstroIntegration => ({
         });
       }
 
-      if (globalThis.process && process.versions.node < "19.0.0") {
+      const edge = ['@astrojs/vercel/edge', '@astrojs/cloudflare'].includes(astroConfig.adapter.name)
+
+      if (!edge && globalThis.process && process.versions.node < "19.0.0") {
         injectScript(
           "page-ssr",
           `import crypto from "node:crypto";


### PR DESCRIPTION
I found the problem with the vercel edge adapter. For some reason on vercel (but not for cloudflare) we have an issue where we resolve the polyfill on the edge adapter. Feel free to add any other non-node adapters if you know of any that might need it