### PR TITLE
bugfix: correctly check if node_env is production

### DIFF
--- a/src/integration.ts
+++ b/src/integration.ts
@@ -31,7 +31,7 @@ export default (config: AstroAuthConfig): AstroIntegration => ({
 				astroConfig.adapter.name
 			)
 
-			if (!edge && globalThis.process && process.versions.node < '19.0.0' && process.env.NODE_ENV === 'production') {
+			if (!edge && globalThis.process && process.versions.node < '19.0.0' || (process.env.NODE_ENV === 'development' && edge)) {
 				injectScript(
 					'page-ssr',
 					`import crypto from "node:crypto";

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -31,7 +31,7 @@ export default (config: AstroAuthConfig): AstroIntegration => ({
 				astroConfig.adapter.name
 			)
 
-			if (!edge && globalThis.process && process.versions.node < '19.0.0' && !process.env.NODE_ENV || 'development') {
+			if (!edge && globalThis.process && process.versions.node < '19.0.0' && process.env.NODE_ENV === 'production') {
 				injectScript(
 					'page-ssr',
 					`import crypto from "node:crypto";


### PR DESCRIPTION
@nowaythatworked @TheOtterlord

This should be the correct fix. When running locally there is no Web Crypto API available, but that is only used when an edge adapter is configured. So we only need to make sure the node crypto API is used in local edge environment. 👍 