### PR TITLE
Implement file-based config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,32 +26,19 @@ Next you need to [add the integration to your astro config](https://docs.astro.b
 
 ## Configuration
 
-Your [auth configuartion](https://authjs.dev/getting-started/oauth-tutorial#creating-the-server-config) needs to be passed to the integration function call.
+Create your [auth configuartion](https://authjs.dev/getting-started/oauth-tutorial#creating-the-server-config) file in the root of your project.
 
-For example:
-```ts title="astro.config.ts"
-import { defineConfig } from 'astro/config';
-import { loadEnv } from 'vite';
-import node from '@astrojs/node';
-import auth from 'auth-astro'
+```ts title="auth.config.ts"
 import GitHub from '@auth/core/providers/github'
 
-const env = loadEnv('production', process.cwd(), '');
-
-export default defineConfig({
-  output: 'server',
-  adapter: node({
-    mode: 'standalone'
-  }),
-  integrations: [auth({
-    providers: [
-      GitHub({
-        clientId: env.GITHUB_CLIENT_ID,
-        clientSecret: env.GITHUB_CLIENT_SECRET,
-      }),
-    ]
-  })]
-})
+export default {
+  providers: [
+    GitHub({
+      clientId: env.GITHUB_CLIENT_ID,
+      clientSecret: env.GITHUB_CLIENT_SECRET,
+    }),
+  ]
+}
 ```
 
 Some OAuth Providers request a callback URL be submitted alongside requesting a Client ID, and Client Secret. The callback URL used by the providers must be set to the following, unless you override the prefix field in the configuration:

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,6 @@
-import type { AuthConfig } from '@auth/core/types'
 import type { PluginOption } from 'vite'
 
-export const virtualConfigModule = (config: AstroAuthConfig): PluginOption => {
+export const virtualConfigModule = (configFile: string = "./auth.config"): PluginOption => {
 	const virtualModuleId = 'auth:config'
 	const resolvedId = '\0' + virtualModuleId
 
@@ -14,13 +13,13 @@ export const virtualConfigModule = (config: AstroAuthConfig): PluginOption => {
 		},
 		load: (id) => {
 			if (id === resolvedId) {
-				return `export default ${JSON.stringify(config)}`
+				return `import authConfig from "${configFile}"; export default authConfig`
 			}
 		},
 	}
 }
 
-export interface AstroAuthConfig extends AuthConfig {
+export interface AstroAuthConfig {
 	/**
 	 * Defines the base path for the auth routes.
 	 * @default '/api/auth'
@@ -31,4 +30,8 @@ export interface AstroAuthConfig extends AuthConfig {
 	 * @default true
 	 */
 	injectEndpoints?: boolean
+  /**
+   * Path to the config file
+   */
+  configFile?: string
 }

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -2,7 +2,7 @@ import type { AstroIntegration } from 'astro'
 import { dirname, join } from 'path'
 import { type AstroAuthConfig, virtualConfigModule } from './config'
 
-export default (config: AstroAuthConfig): AstroIntegration => ({
+export default (config: AstroAuthConfig = {}): AstroIntegration => ({
 	name: 'astro-auth',
 	hooks: {
 		'astro:config:setup': ({ config: astroConfig, injectRoute, injectScript, updateConfig }) => {
@@ -13,7 +13,7 @@ export default (config: AstroAuthConfig): AstroIntegration => ({
 
 			updateConfig({
 				vite: {
-					plugins: [virtualConfigModule(config)],
+					plugins: [virtualConfigModule(config.configFile)],
 				},
 			})
 


### PR DESCRIPTION
Implements #21 to replace the old integration config. I had originally added backwards compatibility to this, but it's probably best we don't lead people down the wrong path, especially with how easy it is to migrate. Even if it means another breaking change, supporting the old version makes little sense.

Closes #21, #22, and #23 
