### PR TITLE
Fix monorepo config handling (#23)

### DIFF
--- a/src/integration.ts
+++ b/src/integration.ts
@@ -14,6 +14,7 @@ export default (config: AstroAuthConfig = {}): AstroIntegration => ({
 			updateConfig({
 				vite: {
 					plugins: [virtualConfigModule(config.configFile)],
+					optimizeDeps: { exclude: ['auth:config'] },
 				},
 			})
 
@@ -31,7 +32,10 @@ export default (config: AstroAuthConfig = {}): AstroIntegration => ({
 				astroConfig.adapter.name
 			)
 
-			if (!edge && globalThis.process && process.versions.node < '19.0.0' || (process.env.NODE_ENV === 'development' && edge)) {
+			if (
+				(!edge && globalThis.process && process.versions.node < '19.0.0') ||
+				(process.env.NODE_ENV === 'development' && edge)
+			) {
 				injectScript(
 					'page-ssr',
 					`import crypto from "node:crypto";


### PR DESCRIPTION
This fixes configuration handling in a monorepo by adding `auth:config` to Vite's `optimizeDeps` property, fixing #23.  There is also a small formatting change, presumably due to files being changed without being formatted after.