### PR TITLE
Astro lowercase endpoint to upper case error

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -108,10 +108,10 @@ export function AstroAuth(options = authConfig) {
 
 	const handler = AstroAuthHandler(prefix, authOptions)
 	return {
-		async get(event: any) {
+		async GET(event: any) {
 			return await handler(event)
 		},
-		async post(event: any) {
+		async POST(event: any) {
 			return await handler(event)
 		},
 	}

--- a/src/api/[...auth].ts
+++ b/src/api/[...auth].ts
@@ -1,3 +1,3 @@
 import { AstroAuth } from '../../server'
 
-export const { get, post } = AstroAuth()
+export const { GET, POST } = AstroAuth()


### PR DESCRIPTION
Astro gives this error message due to lowercase HTTP request methods due to version updates. Uppercase will be valid from Astro 4.0.  I have changed it to uppercase in this pull request
[astro] Lower case endpoint names are deprecated and will not be supported in Astro 4.0. Rename the endpoint get to GET.
[astro] Lower case endpoint names are deprecated and will not be supported in Astro 4.0. Rename the endpoint post to POST.