### PR TITLE
Added `node:` prefix to Astro integration `path` import

### DIFF
--- a/src/integration.ts
+++ b/src/integration.ts
@@ -1,5 +1,5 @@
 import type { AstroIntegration } from 'astro'
-import { dirname, join } from 'path'
+import { dirname, join } from 'node:path'
 import { type AstroAuthConfig, virtualConfigModule } from './config'
 
 export default (config: AstroAuthConfig = {}): AstroIntegration => ({


### PR DESCRIPTION
### What's been changed?

 - Updated Astro integration
	 - Added `node:` prefix to Astro integration `path` import

### Why is this change needed?

I just attempted to set up a new Astro project & added the Cloudflare integration but got the following build error when running locally:
```bash
23:24:57 [build] Rearranging server assets...
✘ [ERROR] Could not resolve "path"

    dist/$server_build/chunks/pages/__iUu0KqP4.mjs:1:7:
      1 │ import 'path';
        ╵        ~~~~~~

  The package "path" wasn't found on the file system but is built into node. Are you trying to
  bundle for node? You can use "platform: 'node'" to do that, which will remove this error.

Could not resolve "path"
```

As mentioned in [the official Astro documentation](https://docs.astro.build/en/guides/integrations-guide/cloudflare/#nodejs-compatibility) all (supported) Node.js modules should have a `node:` prefix added to them. This minor change will fix that.