### PR TITLE
Support endpoints setting multiple cookies in one response

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 	},
 	"devDependencies": {
 		"@auth/core": "^0.18.6",
-		"@types/cookie": "^0.5.1",
 		"@types/node": "^18.11.18",
 		"@types/set-cookie-parser": "^2.4.2",
 		"astro": "^4.0.0",
@@ -33,7 +32,6 @@
 		"typescript": "^4.9.4"
 	},
 	"dependencies": {
-		"cookie": "^0.5.0",
 		"next-auth": "^4.18.8",
 		"set-cookie-parser": "^2.5.1"
 	},

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,7 +37,7 @@ export interface AstroAuthConfig {
 	configFile?: string
 }
 
-export interface FullAuthConfig extends AstroAuthConfig, AuthConfig {}
+export interface FullAuthConfig extends AstroAuthConfig, Omit<AuthConfig, 'raw'> {}
 export const defineConfig = (config: FullAuthConfig) => {
 	config.prefix ??= '/api/auth'
 	return config

--- a/yarn.lock
+++ b/yarn.lock
@@ -633,11 +633,6 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
   integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
 
-"@types/cookie@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.npmjs.org/@types/cookie/-/cookie-0.5.1.tgz"
-  integrity sha512-COUnqfB2+ckwXXSFInsFdOAWQzCCx+a5hq2ruyj+Vjund94RJQd4LG2u9hnvJrTgunKAaax7ancBYlDrNYxA0g==
-
 "@types/debug@^4.0.0":
   version "4.1.7"
   resolved "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz"


### PR DESCRIPTION
Fixes #53

This updates `server.ts` to properly respond with multiple `Set-Cookie` headers if multiple cookies have been set.

It operates as follows:

1. Splits any existing `Set-Cookie` header value returned from `@auth/core` (which may have multiple comma-delimited values, which is not supported for this header)
2. Parses each cookie with `set-cookie-parser` (which the earlier prefer-one-cookie approach already used)
3. Sets each cookie using Astro's `cookies.set` API instead and discards the original munged header

Additional changes in this PR:

- Remove the now-unused `cookie` package and its types
- Update typings in `server.ts` to reference Astro's `APIContext` type where appropriate
- Update `FullAuthConfig`'s typing to reference the correct overload of `@auth/core`'s `Auth` function to get access to correct `Headers` typings from its return value
  - As far as I can tell, the code was already assuming this overload was in use (I saw at least one type error because of this assumption earlier when it was picking up the wrong overload)
  - This change precludes the use of `raw` in `FullAuthConfig`. As per the previous bullet I suspect that would not have worked before anyway, and `raw` is generally only intended for libraries, not consumers, so I wouldn't expect users of this package to have specified it.

I have been able to verify that these changes work in the project where I encountered #53; with this patch, I am able to log in using discord auth and redirect back to the page I came from, which did not work previously due to the `callback-url` cookie getting dropped (it would always redirect to `/`). I would certainly appreciate if others have projects they'd be willing to test this changeset in (I'll be posting a patch usable with `patch-package` in the original issue I opened).