### PR TITLE
fix read me Auth section

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,14 +152,14 @@ Alternatively, you can use the `Auth` component to fetch the session using a ren
 ```tsx title="src/pages/index.astro"
 ---
 import type { Session } from '@auth/core/types';
-import { Auth, Signin, Signout } from 'auth-astro/components';
+import { Auth, SignOut, SignIn } from 'auth-astro/components';
 ---
 <Auth>
   {(session: Session) => 
     {session ? 
-      <Signin provider="github">Login</Signin>
+      <SignOut>Logout</SignOut>
     :
-      <Signout>Logout</Signout>
+      <SignIn provider="github">Login</SignIn>
     }
 
     <p>


### PR DESCRIPTION
Read me, fetching the session in Auth component section was outdated. Also the ternary operator is supposed to be reversed. 