### PR TITLE
feat: Add APIContext object to Auth Config

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -1,5 +1,5 @@
 declare module 'auth:config' {
-	const config: import('./src/config').FullAuthConfig
+	const config: import('./src/config').UserAuthConfig
 	export default config
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,7 @@
 import type { PluginOption } from 'vite'
 import type { AuthConfig } from '@auth/core/types'
+import type { APIContext, AstroGlobal } from 'astro'
+import type { ActionAPIContext } from 'astro/dist/actions/runtime/store'
 
 export const virtualConfigModule = (configFile: string = './auth.config'): PluginOption => {
 	const virtualModuleId = 'auth:config'
@@ -27,7 +29,7 @@ export interface AstroAuthConfig {
 	 */
 	prefix?: string
 	/**
-	 * Defineds wether or not you want the integration to handle the API routes
+	 * Defines whether or not you want the integration to handle the API routes
 	 * @default true
 	 */
 	injectEndpoints?: boolean
@@ -43,3 +45,9 @@ export const defineConfig = (config: FullAuthConfig) => {
 	config.basePath = config.prefix
 	return config
 }
+
+export type UserAuthConfig =
+	| {
+			config: (ctx: APIContext | AstroGlobal | ActionAPIContext) => FullAuthConfig | Promise<FullAuthConfig>
+	  }
+	| FullAuthConfig

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -32,7 +32,7 @@ export default (config: AstroAuthConfig = {}): AstroIntegration => ({
 				injectRoute({
 					pattern: config.prefix + '/[...auth]',
 					entrypoint: entrypoint,
-					entryPoint: entrypoint
+					entryPoint: entrypoint,
 				})
 			}
 


### PR DESCRIPTION
Adds an option to the Auth Config file where users can define a function which accepts the Astro global object (for Astro pages/components) or the APIContext object (for API Routes).

This allows Cloudflare D1 users to use the environment provided by the cloudflare bindings, rather the the vite environment variables.

Adds getSessionByContext(), which allow fetching the session when using a lazy auth config.

Fixes nowaythatworked#60, nowaythatworked#52, nowaythatworked#50.