### PR TITLE
fix: re-add next-auth dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
 		"@types/node": "^18.17.1",
 		"@types/set-cookie-parser": "^2.4.2",
 		"astro": "^5.0.0",
-		"next-auth": "^4.24.10",
 		"prettier": "^2.8.6",
 		"prettier-plugin-astro": "^0.8.0",
 		"typescript": "^5.6.2"
 	},
 	"dependencies": {
+		"next-auth": "^4.24.10",
 		"set-cookie-parser": "^2.5.1"
 	},
 	"keywords": [


### PR DESCRIPTION
Reintegrate next-auth dependency into package.json

This update reinstates the next-auth dependency within the main dependencies section of package.json, instead of under devDependencies. This resolves an issue where the library was unavailable during both development and runtime, as next-auth is essential for the proper execution of the project, not just for development purposes.

![image](https://github.com/user-attachments/assets/fe966d94-ff8c-4370-995a-19099695d7ca)
