### PR TITLE
enable strict TypeScript, fix type-unsafe access of astroConfig.adapter.name

### DIFF
--- a/src/integration.ts
+++ b/src/integration.ts
@@ -30,12 +30,12 @@ export default (config: AstroAuthConfig = {}): AstroIntegration => ({
 				})
 			}
 
+			let edge = false
 			if (!astroConfig.adapter) {
 				logger.error('No Adapter found, please make sure you provide one in your Astro config')
+			} else {
+				edge = ['@astrojs/vercel/edge', '@astrojs/cloudflare'].includes(astroConfig.adapter.name)
 			}
-			const edge = ['@astrojs/vercel/edge', '@astrojs/cloudflare'].includes(
-				astroConfig.adapter.name
-			)
 
 			if (
 				(!edge && globalThis.process && process.versions.node < '19.0.0') ||

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "astro/tsconfigs/base",
+	"extends": "astro/tsconfigs/strict",
 	"compilerOptions": {
 		"types": ["astro/client"],
 		"moduleResolution": "Node"


### PR DESCRIPTION
I had strict astro TypeScript configs enabled on my project, and noticed this error, which is reasonably fixed with a small refactor in the logic to avoid accessing `name` on the astroConfig.adapter if it isn't set.