### PR TITLE
feat: require Node.js 20+ and remove crypto polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"main": "./index.ts",
 	"types": "module.d.ts",
 	"engines": {
-		"node": ">=17.4"
+		"node": ">=20.0.0"
 	},
 	"license": "MIT",
 	"repository": "https://github.com/nowaythatworked/auth-astro.git",

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -37,10 +37,7 @@ export default (config: AstroAuthConfig = {}): AstroIntegration => ({
 				astroConfig.adapter.name
 			)
 
-			if (
-				(!edge && globalThis.process && process.versions.node < '19.0.0') ||
-				(process.env.NODE_ENV === 'development' && edge)
-			) {
+			if ((process.env.NODE_ENV === 'development' && edge)) {
 				injectScript(
 					'page-ssr',
 					`import crypto from "node:crypto";


### PR DESCRIPTION
Node.js versions below 20 are end-of-life. Node 20+ has native Web Crypto API support, eliminating the need for crypto polyfills in the integration.

Update engine requirement to >=20.0.0 and remove conditional crypto injection script from integration setup.