### PR TITLE
fix: update Astro peer dependency to require v5.0.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	},
 	"peerDependencies": {
 		"@auth/core": "^0.37.3",
-		"astro": ">=4.0.0"
+		"astro": ">=5.0.0"
 	},
 	"devDependencies": {
 		"@auth/core": "^0.37.3",


### PR DESCRIPTION
Update peer dependency requirement from >=4.0.0 to >=5.0.0 to match the Astro version used in development dependencies and ensure compatibility with current Astro features.