### PR TITLE
fix: add module declaration for .astro files

### DIFF
--- a/components.ts
+++ b/components.ts
@@ -1,3 +1,6 @@
+// noinspection JSUnusedGlobalSymbols
 export { default as Auth } from './src/components/Auth.astro'
+// noinspection JSUnusedGlobalSymbols
 export { default as SignIn } from './src/components/SignIn.astro'
+// noinspection JSUnusedGlobalSymbols
 export { default as SignOut } from './src/components/SignOut.astro'

--- a/src/astro.d.ts
+++ b/src/astro.d.ts
@@ -1,0 +1,5 @@
+declare module '*.astro' {
+	import type { AstroComponentFactory } from 'astro'
+	const Component: AstroComponentFactory
+	export default Component
+}


### PR DESCRIPTION
Added src/astro.d.ts declaring *.astro modules for TypeScript. Silenced IDE unused export warnings with noinspection comments. Ensures smooth local development without affecting build output or package consumers.