### PR TITLE
feat: dynamic configs based on APIContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,35 @@ AUTH_TRUST_HOST=true
 #### Deploying to Vercel?
 Setting `AUTH_TRUST_HOST` is not needed, as we also check for an active Vercel environment.
 
+### Dynamic Configuration
+
+Some database providers, like Cloudflare D1, provide bindings to your databases in the runtime
+environment, which isn't statically accessible, yet provided on each request. You can define
+your configuration as a function which accepts the `APIContext` from API Routes (equivalent to
+the Astro global value for Astro pages/components).
+
+```ts title="auth.config.ts"
+// auth.config.ts
+import GitHub from '@auth/core/providers/github'
+import { DrizzleAdapter } from "@auth/drizzle-adapter";
+import { defineConfig } from "auth-astro";
+import { drizzle } from "drizzle-orm/d1";
+
+export default defineConfig(function(ctx) {
+  const { env } = ctx.locals.runtime;
+  const db = env.DB;
+  return {
+    adapter: DrizzleAdapter(drizzle(db)),
+    providers: [
+      GitHub({
+        clientId: import.meta.env.GITHUB_CLIENT_ID,
+        clientSecret: import.meta.env.GITHUB_CLIENT_SECRET,
+      }),
+    ],
+  }
+})
+```
+
 ### Requirements
 - Node version `>= 17.4`
 - Astro config set to output mode `server`
@@ -139,7 +168,7 @@ You can fetch the session in one of two ways. The `getSession` method can be use
 ---
 import { getSession } from 'auth-astro/server';
 
-const session = await getSession(Astro.request)
+const session = await getSession(Astro)
 ---
 {session ? (
   <p>Welcome {session.user?.name}</p>

--- a/server.ts
+++ b/server.ts
@@ -28,6 +28,7 @@ import type { AuthAction, Session } from '@auth/core/types'
 import type { APIContext } from 'astro'
 import { parseString } from 'set-cookie-parser'
 import authConfig from 'auth:config'
+import { extractConfig, type SpecifiedAuthConfig } from './src/config'
 
 const actions: AuthAction[] = [
 	'providers',
@@ -40,28 +41,29 @@ const actions: AuthAction[] = [
 	'error',
 ]
 
-function AstroAuthHandler(prefix: string, options = authConfig) {
-	return async ({ cookies, request }: APIContext) => {
-		const url = new URL(request.url)
-		const action = url.pathname.slice(prefix.length + 1).split('/')[0] as AuthAction
+async function AstroAuthHandler(context: APIContext, config: SpecifiedAuthConfig) {
+	const { cookies, request } = context
+	const { prefix } = config
 
-		if (!actions.includes(action) || !url.pathname.startsWith(prefix + '/')) return
+	const url = new URL(request.url)
+	const action = url.pathname.slice(prefix.length + 1).split('/')[0] as AuthAction
 
-		const res = await Auth(request, options)
-		if (['callback', 'signin', 'signout'].includes(action)) {
-			// Properly handle multiple Set-Cookie headers (they can't be concatenated in one)
-			const getSetCookie = res.headers.getSetCookie()
-			if (getSetCookie.length > 0) {
-				getSetCookie.forEach((cookie) => {
-					const { name, value, ...options } = parseString(cookie)
-					// Astro's typings are more explicit than @types/set-cookie-parser for sameSite
-					cookies.set(name, value, options as Parameters<(typeof cookies)['set']>[2])
-				})
-				res.headers.delete('Set-Cookie')
-			}
+	if (!actions.includes(action) || !url.pathname.startsWith(prefix + '/')) return
+
+	const res = await Auth(request, config)
+	if (['callback', 'signin', 'signout'].includes(action)) {
+		// Properly handle multiple Set-Cookie headers (they can't be concatenated in one)
+		const getSetCookie = res.headers.getSetCookie()
+		if (getSetCookie.length > 0) {
+			getSetCookie.forEach((cookie) => {
+				const { name, value, ...options } = parseString(cookie)
+				// Astro's typings are more explicit than @types/set-cookie-parser for sameSite
+				cookies.set(name, value, options as Parameters<(typeof cookies)['set']>[2])
+			})
+			res.headers.delete('Set-Cookie')
 		}
-		return res
 	}
+	return res
 }
 
 /**
@@ -86,34 +88,37 @@ export function AstroAuth(options = authConfig) {
 	// @ts-ignore
 	const { AUTH_SECRET, AUTH_TRUST_HOST, VERCEL, NODE_ENV } = import.meta.env
 
-	options.secret ??= AUTH_SECRET
-	options.trustHost ??= !!(AUTH_TRUST_HOST ?? VERCEL ?? NODE_ENV !== 'production')
+	const prepareConfig = (context: APIContext): SpecifiedAuthConfig => {
+		const config = extractConfig(options, context)
+		config.secret ??= AUTH_SECRET
+		config.trustHost ??= !!(AUTH_TRUST_HOST ?? VERCEL ?? NODE_ENV !== 'production')
+		config.prefix ??= '/api/auth'
+		return config
+	}
 
-	const { prefix = '/api/auth', ...authOptions } = options
-
-	const handler = AstroAuthHandler(prefix, authOptions)
 	return {
 		async GET(context: APIContext) {
-			return await handler(context)
+			return await AstroAuthHandler(context, prepareConfig(context))
 		},
 		async POST(context: APIContext) {
-			return await handler(context)
+			return await AstroAuthHandler(context, prepareConfig(context))
 		},
 	}
 }
 
 /**
  * Fetches the current session.
- * @param req The request object.
+ * @param context The API context object. If you are in a page, you can also pass in Astro directly.
  * @returns The current session, or `null` if there is no session.
  */
-export async function getSession(req: Request, options = authConfig): Promise<Session | null> {
-	// @ts-ignore
+export async function getSession(context: APIContext, config = authConfig): Promise<Session | null> {
+	const options = extractConfig(config, context)
+	// @ts-ignore for import.meta
 	options.secret ??= import.meta.env.AUTH_SECRET
 	options.trustHost ??= true
 
-	const url = new URL(`${options.prefix}/session`, req.url)
-	const response = await Auth(new Request(url, { headers: req.headers }), options)
+	const url = new URL(`${options.prefix}/session`, context.url)
+	const response = await Auth(new Request(url, { headers: context.request.headers }), options)
 	const { status = 200 } = response
 
 	const data = await response.json()

--- a/server.ts
+++ b/server.ts
@@ -88,8 +88,8 @@ export function AstroAuth(options = authConfig) {
 	// @ts-ignore
 	const { AUTH_SECRET, AUTH_TRUST_HOST, VERCEL, NODE_ENV } = import.meta.env
 
-	const prepareConfig = (context: APIContext): SpecifiedAuthConfig => {
-		const config = extractConfig(options, context)
+	const prepareConfig = async (context: APIContext): Promise<SpecifiedAuthConfig> => {
+		const config = await extractConfig(options, context)
 		config.secret ??= AUTH_SECRET
 		config.trustHost ??= !!(AUTH_TRUST_HOST ?? VERCEL ?? NODE_ENV !== 'production')
 		config.prefix ??= '/api/auth'
@@ -98,10 +98,10 @@ export function AstroAuth(options = authConfig) {
 
 	return {
 		async GET(context: APIContext) {
-			return await AstroAuthHandler(context, prepareConfig(context))
+			return await AstroAuthHandler(context, await prepareConfig(context))
 		},
 		async POST(context: APIContext) {
-			return await AstroAuthHandler(context, prepareConfig(context))
+			return await AstroAuthHandler(context, await prepareConfig(context))
 		},
 	}
 }
@@ -112,7 +112,7 @@ export function AstroAuth(options = authConfig) {
  * @returns The current session, or `null` if there is no session.
  */
 export async function getSession(context: APIContext, config = authConfig): Promise<Session | null> {
-	const options = extractConfig(config, context)
+	const options = await extractConfig(config, context)
 	// @ts-ignore for import.meta
 	options.secret ??= import.meta.env.AUTH_SECRET
 	options.trustHost ??= true

--- a/src/components/Auth.astro
+++ b/src/components/Auth.astro
@@ -9,7 +9,7 @@ interface Props {
 
 const { authConfig = authDefaultConfig } = Astro.props as Props
 
-let session = await getSession(Astro.request, authConfig)
+let session = await getSession(Astro, authConfig)
 ---
 
 <div>

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,20 +39,20 @@ export interface AstroAuthConfig {
 }
 
 export interface SpecifiedAuthConfig extends AstroAuthConfig, Omit<AuthConfig, 'raw'> {}
-export type DynamicAuthConfig = (context: APIContext) => SpecifiedAuthConfig
+export type DynamicAuthConfig = (context: APIContext) => Promise<SpecifiedAuthConfig>
 export type FullAuthConfig = SpecifiedAuthConfig | DynamicAuthConfig
 
-export function extractConfig(config: FullAuthConfig, context: APIContext): SpecifiedAuthConfig {
+export async function extractConfig(config: FullAuthConfig, context: APIContext): Promise<SpecifiedAuthConfig> {
 	if (typeof config === 'function') {
-		return config(context)
+		return await config(context)
 	}
 
 	return config
 }
 
 export function defineConfig(config: FullAuthConfig): FullAuthConfig {
-	return context => {
-		const extractedConfig = extractConfig(config, context)
+	return async context => {
+		const extractedConfig = await extractConfig(config, context)
 		extractedConfig.prefix ??= '/api/auth'
 		extractedConfig.basePath = extractedConfig.prefix
 		return extractedConfig

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import type { PluginOption } from 'vite'
 import type { AuthConfig } from '@auth/core/types'
+import type { APIContext, AstroGlobal } from 'astro'
 
 export const virtualConfigModule = (configFile: string = './auth.config'): PluginOption => {
 	const virtualModuleId = 'auth:config'
@@ -27,7 +28,7 @@ export interface AstroAuthConfig {
 	 */
 	prefix?: string
 	/**
-	 * Defineds wether or not you want the integration to handle the API routes
+	 * Defines whether or not you want the integration to handle the API routes
 	 * @default true
 	 */
 	injectEndpoints?: boolean
@@ -37,9 +38,23 @@ export interface AstroAuthConfig {
 	configFile?: string
 }
 
-export interface FullAuthConfig extends AstroAuthConfig, Omit<AuthConfig, 'raw'> {}
-export const defineConfig = (config: FullAuthConfig) => {
-	config.prefix ??= '/api/auth'
-	config.basePath = config.prefix
+export interface SpecifiedAuthConfig extends AstroAuthConfig, Omit<AuthConfig, 'raw'> {}
+export type DynamicAuthConfig = (context: APIContext) => SpecifiedAuthConfig
+export type FullAuthConfig = SpecifiedAuthConfig | DynamicAuthConfig
+
+export function extractConfig(config: FullAuthConfig, context: APIContext): SpecifiedAuthConfig {
+	if (typeof config === 'function') {
+		return config(context)
+	}
+
 	return config
+}
+
+export function defineConfig(config: FullAuthConfig): FullAuthConfig {
+	return context => {
+		const extractedConfig = extractConfig(config, context)
+		extractedConfig.prefix ??= '/api/auth'
+		extractedConfig.basePath = extractedConfig.prefix
+		return extractedConfig
+	}
 }


### PR DESCRIPTION
Allows for a dynamic auth config per route by passing in the entire `APIContext`.

This comes with a breaking change for `getSession` - specifically, its first variable now requires the entire `Astro` context over just `Astro.request`.

Closes #60, closes #52, closes #50, supersedes #81.

Co-authored-by: JordanSekky <6587879+JordanSekky@users.noreply.github.com>